### PR TITLE
Add support for specifying object name in body

### DIFF
--- a/appscale/cloud_storage/objects.py
+++ b/appscale/cloud_storage/objects.py
@@ -238,6 +238,10 @@ def insert_object(bucket_name, upload_type, conn):
     object_name = request.args.get('name', default=None)
     upload_id = request.args.get('upload_id', default=None)
 
+    if object_name is None:
+        request_data = request.get_json()
+        object_name = request_data.get('name')
+
     if upload_type == 'media':
         if object_name is None:
             return error('Object name is required.', HTTP_BAD_REQUEST)

--- a/appscale/cloud_storage/objects.py
+++ b/appscale/cloud_storage/objects.py
@@ -238,10 +238,6 @@ def insert_object(bucket_name, upload_type, conn):
     object_name = request.args.get('name', default=None)
     upload_id = request.args.get('upload_id', default=None)
 
-    if object_name is None:
-        request_data = request.get_json()
-        object_name = request_data.get('name')
-
     if upload_type == 'media':
         if object_name is None:
             return error('Object name is required.', HTTP_BAD_REQUEST)
@@ -263,7 +259,11 @@ def insert_object(bucket_name, upload_type, conn):
         return Response(json.dumps(obj), mimetype='application/json')
     if upload_type == 'resumable' and upload_id is None:
         if object_name is None:
-            return error('Object name is required.', HTTP_BAD_REQUEST)
+            request_data = request.get_json()
+            try:
+                object_name = request_data['name']
+            except KeyError:
+                return error('Object name is required.', HTTP_BAD_REQUEST)
 
         new_upload_id = ''.join(
             random.choice(current_app.config['RESUMABLE_ID_CHARS'])


### PR DESCRIPTION
This fixes object uploads for clients that do not use URL parameters to specify the object name.